### PR TITLE
Update runtime to 50

### DIFF
--- a/io.github.nokse22.teleprompter.json
+++ b/io.github.nokse22.teleprompter.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.nokse22.teleprompter",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "48",
+    "runtime-version" : "50",
     "sdk" : "org.gnome.Sdk",
     "command" : "teleprompter",
     "finish-args" : [
@@ -10,31 +10,7 @@
         "--device=dri",
         "--socket=wayland"
     ],
-    "cleanup" : [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
-    ],
     "modules" : [
-        {
-    	  "name": "blueprint-compiler",
-    	  "buildsystem": "meson",
-    	  "sources": [
-    	    {
-    	      "type": "git",
-    	      "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-    	      "tag": "v0.16.0",
-    	      "commit": "04ef0944db56ab01307a29aaa7303df6067cb3c0"
-    	    }
-    	  ],
-    	  "cleanup": ["*"]
-    	},
         {
             "name" : "teleprompter",
             "builddir" : true,


### PR DESCRIPTION
- Update runtime to 50
- Drop ineffective cleanup commands
- Drop the blueprint-compiler module, which is already provided by the runtime